### PR TITLE
Updated base image for http trigger

### DIFF
--- a/docker/http-controller/Dockerfile
+++ b/docker/http-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/minideb:jessie
+FROM bitnami/minideb:stretch
 
 ADD http-controller /http-controller
 


### PR DESCRIPTION
**Issue Ref**:  https://github.com/kubeless/kubeless/issues/1243
 
**Description**: 
Kubeless uses bitnami/minideb:jessie as it's base for a number of components. Minideb is a slimmed down packaging of upstream Debian and as such they provide no additional security patching beyond what's provided by Debian upstream. Debian Jessie was EOL as of Jan 2020 and no longer receives security updates.

As a result the containers based on minideb:jessie are growing a steadily longer list of critical CVE. The recommended action would be to rebase on a supported version of minideb/debian. Stretch is an option for LTS support until 2022 and is well supported by the minideb project.

Here is an example of a current scan on function-controller:latest performed by grype. All of the other core framework components using minideb:jessie have similar results.

✔ Vulnerability DB [no update available]
✔ Cataloged packages [78 packages]
✔ Scanned image [202 vulnerabilities]

NAME               INSTALLED              FIXED-IN     VULNERABILITY     SEVERITY   
apt                1.0.9.8.6                           CVE-2011-3374     Negligible  
bash               4.3-11+deb8u2                       CVE-2019-18276    Negligible  
bsdutils           1:2.25.2-6                          CVE-2017-2616     Medium      
bsdutils           1:2.25.2-6             (won't fix)  CVE-2016-5011     Medium      
bsdutils           1:2.25.2-6                          CVE-2015-5224     Negligible  
bsdutils           1:2.25.2-6                          CVE-2015-5218     Negligible  
bsdutils           1:2.25.2-6             (won't fix)  CVE-2016-2779     High        
coreutils          8.23-4                 (won't fix)  CVE-2016-2781     Low         
coreutils          8.23-4                              CVE-2017-18018    Negligible  
dpkg               1.17.27                             CVE-2017-8283     Negligible  
gcc-4.9-base       4.9.2-10+deb8u2        (won't fix)  CVE-2018-12886    Medium      
gcc-4.9-base       4.9.2-10+deb8u2        (won't fix)  CVE-2015-5276     Medium      
gcc-4.9-base       4.9.2-10+deb8u2        (won't fix)  CVE-2017-11671    Low         
gnupg              1.4.18-7+deb8u5                     CVE-2018-6829     Negligible  
gnupg              1.4.18-7+deb8u5        (won't fix)  CVE-2019-14855    Low         
gpgv               1.4.18-7+deb8u5                     CVE-2018-6829     Negligible  
gpgv               1.4.18-7+deb8u5        (won't fix)  CVE-2019-14855    Low         
libapt-pkg4.12     1.0.9.8.6                           CVE-2011-3374     Negligible  
libaudit-common    1:2.4-1                             CVE-2015-5186     Negligible  
libaudit1          1:2.4-1+b1                          CVE-2015-5186     Negligible  
libblkid1          2.25.2-6                            CVE-2017-2616     Medium      
libblkid1          2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
libblkid1          2.25.2-6                            CVE-2015-5224     Negligible  
libblkid1          2.25.2-6                            CVE-2015-5218     Negligible  
libblkid1          2.25.2-6               (won't fix)  CVE-2016-2779     High        
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2009-5155     Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2018-6485     High        
libc-bin           2.19-18+deb8u10                     CVE-2019-9192     Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-1000408  High        
libc-bin           2.19-18+deb8u10                     CVE-2019-1010023  Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2019-1010024  Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2019-1010025  Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-15671    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-1000409  Medium      
libc-bin           2.19-18+deb8u10                     CVE-2015-8985     Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2018-20796    Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-15804    Low         
libc-bin           2.19-18+deb8u10                     CVE-2019-6488     Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2019-7309     Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2010-4052     Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2010-4051     Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2020-10029    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-12133    Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-12132    Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2015-5180     Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-16997    High        
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2018-1000001  High        
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2019-9169     High        
libc-bin           2.19-18+deb8u10                     CVE-2010-4756     Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-15670    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2014-9761     High        
libc-bin           2.19-18+deb8u10                     CVE-2019-1010022  Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2016-10228    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2018-11236    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2018-11237    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2016-10739    Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2020-1751     Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2020-1752     Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2009-5155     Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2018-6485     High        
libc6              2.19-18+deb8u10                     CVE-2019-9192     Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-1000408  High        
libc6              2.19-18+deb8u10                     CVE-2019-1010023  Negligible  
libc6              2.19-18+deb8u10                     CVE-2019-1010024  Negligible  
libc6              2.19-18+deb8u10                     CVE-2019-1010025  Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-15671    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-1000409  Medium      
libc6              2.19-18+deb8u10                     CVE-2015-8985     Negligible  
libc6              2.19-18+deb8u10                     CVE-2018-20796    Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-15804    Low         
libc6              2.19-18+deb8u10                     CVE-2019-6488     Negligible  
libc6              2.19-18+deb8u10                     CVE-2019-7309     Negligible  
libc6              2.19-18+deb8u10                     CVE-2010-4052     Negligible  
libc6              2.19-18+deb8u10                     CVE-2010-4051     Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2020-10029    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-12133    Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-12132    Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2015-5180     Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-16997    High        
libc6              2.19-18+deb8u10        (won't fix)  CVE-2018-1000001  High        
libc6              2.19-18+deb8u10        (won't fix)  CVE-2019-9169     High        
libc6              2.19-18+deb8u10                     CVE-2010-4756     Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-15670    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2014-9761     High        
libc6              2.19-18+deb8u10                     CVE-2019-1010022  Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2016-10228    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2018-11236    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2018-11237    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2016-10739    Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2020-1751     Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2020-1752     Low         
libgcc1            1:4.9.2-10+deb8u2      (won't fix)  CVE-2018-12886    Medium      
libgcc1            1:4.9.2-10+deb8u2      (won't fix)  CVE-2015-5276     Medium      
libgcc1            1:4.9.2-10+deb8u2      (won't fix)  CVE-2017-11671    Low         
libgcrypt20        1.6.3-2+deb8u8                      CVE-2018-6829     Negligible  
libmount1          2.25.2-6                            CVE-2017-2616     Medium      
libmount1          2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
libmount1          2.25.2-6                            CVE-2015-5224     Negligible  
libmount1          2.25.2-6                            CVE-2015-5218     Negligible  
libmount1          2.25.2-6               (won't fix)  CVE-2016-2779     High        
libncurses5        5.9+20140913-1+deb8u3  (won't fix)  CVE-2018-19211    Low         
libncurses5        5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17594    Low         
libncurses5        5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17595    Low         
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2017-7245     Negligible  
libpcre3           2:8.35-3.3+deb8u4                   CVE-2017-11164    Negligible  
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2017-7186     Medium      
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2017-7246     Negligible  
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2017-7244     Medium      
libpcre3           2:8.35-3.3+deb8u4                   CVE-2017-16231    Negligible  
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2015-3217     Medium      
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2020-14155    Medium      
libpcre3           2:8.35-3.3+deb8u4                   CVE-2019-20838    Negligible  
libsmartcols1      2.25.2-6                            CVE-2017-2616     Medium      
libsmartcols1      2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
libsmartcols1      2.25.2-6                            CVE-2015-5224     Negligible  
libsmartcols1      2.25.2-6                            CVE-2015-5218     Negligible  
libsmartcols1      2.25.2-6               (won't fix)  CVE-2016-2779     High        
libssl1.0.0        1.0.1t-1+deb8u12                    CVE-2007-6755     Negligible  
libssl1.0.0        1.0.1t-1+deb8u12                    CVE-2010-0928     Negligible  
libssl1.0.0        1.0.1t-1+deb8u12       (won't fix)  CVE-2018-0734     Medium      
libstdc++6         4.9.2-10+deb8u2        (won't fix)  CVE-2018-12886    Medium      
libstdc++6         4.9.2-10+deb8u2        (won't fix)  CVE-2015-5276     Medium      
libstdc++6         4.9.2-10+deb8u2        (won't fix)  CVE-2017-11671    Low         
libsystemd0        215-17+deb8u13         (won't fix)  CVE-2018-16888    Low         
libsystemd0        215-17+deb8u13         (won't fix)  CVE-2018-6954     Low         
libsystemd0        215-17+deb8u13                      CVE-2013-4392     Negligible  
libsystemd0        215-17+deb8u13                      CVE-2019-20386    Negligible  
libsystemd0        215-17+deb8u13                      CVE-2020-13776    Negligible  
libtinfo5          5.9+20140913-1+deb8u3  (won't fix)  CVE-2018-19211    Low         
libtinfo5          5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17594    Low         
libtinfo5          5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17595    Low         
libuuid1           2.25.2-6                            CVE-2017-2616     Medium      
libuuid1           2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
libuuid1           2.25.2-6                            CVE-2015-5224     Negligible  
libuuid1           2.25.2-6                            CVE-2015-5218     Negligible  
libuuid1           2.25.2-6               (won't fix)  CVE-2016-2779     High        
login              1:4.2-3+deb8u4                      CVE-2007-5686     Negligible  
login              1:4.2-3+deb8u4         (won't fix)  CVE-2017-12424    High        
login              1:4.2-3+deb8u4                      CVE-2013-4235     Negligible  
login              1:4.2-3+deb8u4                      CVE-2019-19882    Negligible  
login              1:4.2-3+deb8u4         (won't fix)  CVE-2018-7169     Low         
mount              2.25.2-6                            CVE-2017-2616     Medium      
mount              2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
mount              2.25.2-6                            CVE-2015-5224     Negligible  
mount              2.25.2-6                            CVE-2015-5218     Negligible  
mount              2.25.2-6               (won't fix)  CVE-2016-2779     High        
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2009-5155     Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2018-6485     High        
multiarch-support  2.19-18+deb8u10                     CVE-2019-9192     Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-1000408  High        
multiarch-support  2.19-18+deb8u10                     CVE-2019-1010023  Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2019-1010024  Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2019-1010025  Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-15671    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-1000409  Medium      
multiarch-support  2.19-18+deb8u10                     CVE-2015-8985     Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2018-20796    Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-15804    Low         
multiarch-support  2.19-18+deb8u10                     CVE-2019-6488     Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2019-7309     Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2010-4052     Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2010-4051     Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2020-10029    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-12133    Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-12132    Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2015-5180     Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-16997    High        
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2018-1000001  High        
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2019-9169     High        
multiarch-support  2.19-18+deb8u10                     CVE-2010-4756     Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-15670    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2014-9761     High        
multiarch-support  2.19-18+deb8u10                     CVE-2019-1010022  Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2016-10228    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2018-11236    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2018-11237    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2016-10739    Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2020-1751     Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2020-1752     Low         
ncurses-base       5.9+20140913-1+deb8u3  (won't fix)  CVE-2018-19211    Low         
ncurses-base       5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17594    Low         
ncurses-base       5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17595    Low         
openssl            1.0.1t-1+deb8u12                    CVE-2007-6755     Negligible  
openssl            1.0.1t-1+deb8u12                    CVE-2010-0928     Negligible  
openssl            1.0.1t-1+deb8u12       (won't fix)  CVE-2018-0734     Medium      
passwd             1:4.2-3+deb8u4                      CVE-2007-5686     Negligible  
passwd             1:4.2-3+deb8u4         (won't fix)  CVE-2017-12424    High        
passwd             1:4.2-3+deb8u4                      CVE-2013-4235     Negligible  
passwd             1:4.2-3+deb8u4                      CVE-2019-19882    Negligible  
passwd             1:4.2-3+deb8u4         (won't fix)  CVE-2018-7169     Low         
perl-base          5.20.2-3+deb8u12       (won't fix)  CVE-2018-6797     High        
perl-base          5.20.2-3+deb8u12                    CVE-2011-4116     Negligible  
perl-base          5.20.2-3+deb8u12                    CVE-2020-10878    High        
perl-base          5.20.2-3+deb8u12                    CVE-2020-12723    Medium      
perl-base          5.20.2-3+deb8u12                    CVE-2020-10543    Medium      
tar                1.27.1-2+deb8u2                     CVE-2005-2541     Negligible  
tar                1.27.1-2+deb8u2                     CVE-2019-9923     Negligible  
util-linux         2.25.2-6                            CVE-2017-2616     Medium      
util-linux         2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
util-linux         2.25.2-6                            CVE-2015-5224     Negligible  
util-linux         2.25.2-6                            CVE-2015-5218     Negligible  
util-linux         2.25.2-6               (won't fix)  CVE-2016-2779     High  

[PR Description]
In this PR we have changed based image to get latest security fixes.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [X] Docs
